### PR TITLE
feat: Keys of `KEY_VALUE` are now static values and no ParseResults.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is a parser for jsdoc types. It is heavily inspired by the existing
 Live Demo
 ---------
 
-Simple live demo can be found at: https://simonseyock.github.io/jsdoc-type-pratt-parser/
+A simple live demo to test expressions can be found at: https://simonseyock.github.io/jsdoc-type-pratt-parser/
 
 Getting started
 ---------------
@@ -21,7 +21,6 @@ Getting started
 ```
 npm install jsdoc-type-pratt-parser@alpha
 ```
-
 
 ```js
 import { parse } from 'jsdoc-type-pratt-parser'

--- a/src/ParseResult.ts
+++ b/src/ParseResult.ts
@@ -31,7 +31,8 @@ export type ParseResult =
  */
 export type NonTerminalResult =
   ParseResult
-  | KeyValueResult<ParseResult | NameResult | NumberResult>
+  | KeyValueResult
+  | JsdocObjectKeyValueResult
   | NumberResult
 
 /**
@@ -171,9 +172,19 @@ export interface FunctionResult {
  * A key value pair represented by a `:`. Can occur as a named parameter of a {@link FunctionResult} or as an entry for
  * an {@link ObjectResult}. Is a {@link NonTerminalResult}.
  */
-export interface KeyValueResult<KeyType = NameResult> {
+export interface KeyValueResult {
   type: 'KEY_VALUE'
-  left: KeyType
+  value: string
+  right: ParseResult | undefined
+  optional: boolean
+  meta: {
+    quote: '\'' | '"' | undefined
+  }
+}
+
+export interface JsdocObjectKeyValueResult {
+  type: 'JSDOC_OBJECT_KEY_VALUE'
+  left: ParseResult
   right: ParseResult
 }
 
@@ -184,7 +195,7 @@ export interface KeyValueResult<KeyType = NameResult> {
  */
 export interface ObjectResult {
   type: 'OBJECT'
-  elements: Array<KeyValueResult<ParseResult | NumberResult> | ParseResult | NumberResult>
+  elements: Array<KeyValueResult | JsdocObjectKeyValueResult>
 }
 
 /**

--- a/src/assertTypes.ts
+++ b/src/assertTypes.ts
@@ -6,28 +6,22 @@ export function assertTerminal (result?: IntermediateResult): ParseResult {
   if (result === undefined) {
     throw new Error('Unexpected undefined')
   }
-  if (result.type === 'KEY_VALUE' || result.type === 'NUMBER' || result.type === 'PARAMETER_LIST') {
+  if (result.type === 'KEY_VALUE' || result.type === 'NUMBER' || result.type === 'PARAMETER_LIST' || result.type === 'JSDOC_OBJECT_KEY_VALUE') {
     throw new UnexpectedTypeError(result)
   }
   return result
 }
 
-export function assertNamedKeyValueOrTerminal (result: IntermediateResult): KeyValueResult | ParseResult {
+export function assertKeyValueOrTerminal (result: IntermediateResult): KeyValueResult | ParseResult {
   if (result.type === 'KEY_VALUE') {
-    if (result.left.type !== 'NAME') {
-      throw new UnexpectedTypeError(result)
-    }
-    return result as KeyValueResult
+    return result
   }
   return assertTerminal(result)
 }
 
-export function assertNamedKeyValueOrName (result: IntermediateResult): KeyValueResult | NameResult {
+export function assertKeyValueOrName (result: IntermediateResult): KeyValueResult | NameResult {
   if (result.type === 'KEY_VALUE') {
-    if (result.left.type !== 'NAME') {
-      throw new UnexpectedTypeError(result)
-    }
-    return result as KeyValueResult
+    return result
   } else if (result.type !== 'NAME') {
     throw new UnexpectedTypeError(result)
   }

--- a/src/grammars/baseGrammar.ts
+++ b/src/grammars/baseGrammar.ts
@@ -1,7 +1,6 @@
 import { Grammar } from './Grammar'
 import { UnionParslet } from '../parslets/UnionParslets'
 import { SpecialTypesParslet } from '../parslets/SpecialTypesParslet'
-import { ObjectParslet } from '../parslets/ObjectParslet'
 import { GenericParslet } from '../parslets/GenericParslet'
 import { ParenthesisParslet } from '../parslets/ParenthesisParslet'
 import { NumberParslet } from '../parslets/NumberParslet'
@@ -14,7 +13,6 @@ export const baseGrammar: Grammar = () => {
     prefixParslets: [
       new NullablePrefixParslet(),
       new OptionalParslet(),
-      new ObjectParslet(),
       new NumberParslet(),
       new ParenthesisParslet(),
       new SpecialTypesParslet()

--- a/src/grammars/closureGrammar.ts
+++ b/src/grammars/closureGrammar.ts
@@ -7,6 +7,7 @@ import { TypeOfParslet } from '../parslets/TypeOfParslet'
 import { VariadicParslet } from '../parslets/VariadicParslet'
 import { NameParslet } from '../parslets/NameParslet'
 import { NotNullableParslet } from '../parslets/NotNullableParslet'
+import { ObjectParslet } from '../parslets/ObjectParslet'
 
 export const closureGrammar: Grammar = () => {
   const {
@@ -17,6 +18,9 @@ export const closureGrammar: Grammar = () => {
   return {
     prefixParslets: [
       ...prefixParslets,
+      new ObjectParslet({
+        allowKeyTypes: false
+      }),
       new NameParslet({
         allowedAdditionalTokens: ['module', 'event', 'external']
       }),
@@ -40,7 +44,8 @@ export const closureGrammar: Grammar = () => {
         allowJsdocNamePaths: false
       }),
       new KeyValueParslet({
-        allowOnlyNameOrNumberProperties: true
+        allowKeyTypes: false,
+        allowOptional: false
       }),
       new NotNullableParslet()
     ]

--- a/src/grammars/jsdocGrammar.ts
+++ b/src/grammars/jsdocGrammar.ts
@@ -10,6 +10,7 @@ import { VariadicParslet } from '../parslets/VariadicParslet'
 import { SpecialNamePathParslet } from '../parslets/SpecialNamePathParslet'
 import { NameParslet } from '../parslets/NameParslet'
 import { NotNullableParslet } from '../parslets/NotNullableParslet'
+import { ObjectParslet } from '../parslets/ObjectParslet'
 
 export const jsdocGrammar: Grammar = () => {
   const {
@@ -20,6 +21,9 @@ export const jsdocGrammar: Grammar = () => {
   return {
     prefixParslets: [
       ...prefixParslets,
+      new ObjectParslet({
+        allowKeyTypes: true
+      }),
       new FunctionParslet({
         allowWithoutParenthesis: true,
         allowNamedParameters: ['this', 'new'],
@@ -43,7 +47,8 @@ export const jsdocGrammar: Grammar = () => {
         allowJsdocNamePaths: true
       }),
       new KeyValueParslet({
-        allowOnlyNameOrNumberProperties: false
+        allowKeyTypes: true,
+        allowOptional: false
       }),
       new VariadicParslet({
         allowEnclosingBrackets: true

--- a/src/grammars/typescriptGrammar.ts
+++ b/src/grammars/typescriptGrammar.ts
@@ -16,6 +16,7 @@ import { KeyValueParslet } from '../parslets/KeyValueParslet'
 import { VariadicParslet } from '../parslets/VariadicParslet'
 import { NameParslet } from '../parslets/NameParslet'
 import { IntersectionParslet } from '../parslets/IntersectionParslet'
+import { ObjectParslet } from '../parslets/ObjectParslet'
 
 export const typescriptGrammar: Grammar = () => {
   const {
@@ -31,6 +32,9 @@ export const typescriptGrammar: Grammar = () => {
   return {
     prefixParslets: [
       ...prefixParslets,
+      new ObjectParslet({
+        allowKeyTypes: false
+      }),
       new TypeOfParslet(),
       new KeyOfParslet(),
       new ImportParslet(),
@@ -59,7 +63,8 @@ export const typescriptGrammar: Grammar = () => {
         allowJsdocNamePaths: false
       }),
       new KeyValueParslet({
-        allowOnlyNameOrNumberProperties: true
+        allowKeyTypes: false,
+        allowOptional: true
       }),
       new IntersectionParslet()
     ]

--- a/src/parslets/ArrowFunctionParslet.ts
+++ b/src/parslets/ArrowFunctionParslet.ts
@@ -4,7 +4,7 @@ import { Precedence } from '../Precedence'
 import { IntermediateResult, ParserEngine } from '../ParserEngine'
 import { FunctionResult } from '../ParseResult'
 import { BaseFunctionParslet } from './BaseFunctionParslet'
-import { assertNamedKeyValueOrName } from '../assertTypes'
+import { assertKeyValueOrName } from '../assertTypes'
 
 export class ArrowFunctionWithoutParametersParslet implements PrefixParslet {
   accepts (type: TokenType, next: TokenType): boolean {
@@ -46,7 +46,7 @@ export class ArrowFunctionWithParametersParslet extends BaseFunctionParslet impl
 
     return {
       type: 'FUNCTION',
-      parameters: this.getParameters(left).map(assertNamedKeyValueOrName),
+      parameters: this.getParameters(left).map(assertKeyValueOrName),
       arrow: true,
       parenthesis: true,
       returnType: parser.parseType(Precedence.ALL)

--- a/src/parslets/BaseFunctionParslet.ts
+++ b/src/parslets/BaseFunctionParslet.ts
@@ -1,5 +1,5 @@
 import { KeyValueResult, NonTerminalResult, ParseResult } from '../ParseResult'
-import { assertNamedKeyValueOrTerminal } from '../assertTypes'
+import { assertKeyValueOrTerminal } from '../assertTypes'
 import { IntermediateResult } from '../ParserEngine'
 import { UnexpectedTypeError } from '../errors'
 
@@ -14,7 +14,7 @@ export class BaseFunctionParslet {
       throw new UnexpectedTypeError(value)
     }
 
-    return parameters.map(p => assertNamedKeyValueOrTerminal(p))
+    return parameters.map(p => assertKeyValueOrTerminal(p))
   }
 
   protected getNamedParameters (value: IntermediateResult): KeyValueResult[] {

--- a/src/parslets/FunctionParslet.ts
+++ b/src/parslets/FunctionParslet.ts
@@ -54,7 +54,7 @@ export class FunctionParslet extends BaseFunctionParslet implements PrefixParsle
       } else {
         result.parameters = this.getParameters(value)
         for (const p of result.parameters) {
-          if (p.type === 'KEY_VALUE' && !this.allowNamedParameters.includes(p.left.value)) {
+          if (p.type === 'KEY_VALUE' && (!this.allowNamedParameters.includes(p.value) || p.meta.quote !== undefined)) {
             throw new Error(`only allowed named parameters are ${this.allowNamedParameters.join(',')} but got ${p.type}`)
           }
         }

--- a/src/parslets/KeyValueParslet.ts
+++ b/src/parslets/KeyValueParslet.ts
@@ -2,19 +2,22 @@ import { InfixParslet } from './Parslet'
 import { TokenType } from '../lexer/Token'
 import { Precedence } from '../Precedence'
 import { IntermediateResult, ParserEngine } from '../ParserEngine'
-import { KeyValueResult, NumberResult, ParseResult } from '../ParseResult'
+import { JsdocObjectKeyValueResult, KeyValueResult } from '../ParseResult'
 import { assertTerminal } from '../assertTypes'
 import { UnexpectedTypeError } from '../errors'
 
 interface KeyValueParsletOptions {
-  allowOnlyNameOrNumberProperties: boolean
+  allowKeyTypes: boolean
+  allowOptional: boolean
 }
 
 export class KeyValueParslet implements InfixParslet {
-  private readonly allowOnlyNameOrNumberProperties
+  private readonly allowKeyTypes: boolean
+  private readonly allowOptional: boolean
 
   constructor (opts: KeyValueParsletOptions) {
-    this.allowOnlyNameOrNumberProperties = opts.allowOnlyNameOrNumberProperties
+    this.allowKeyTypes = opts.allowKeyTypes
+    this.allowOptional = opts.allowOptional
   }
 
   accepts (type: TokenType, next: TokenType): boolean {
@@ -25,16 +28,43 @@ export class KeyValueParslet implements InfixParslet {
     return Precedence.KEY_VALUE
   }
 
-  parseInfix (parser: ParserEngine, left: IntermediateResult): KeyValueResult<ParseResult | NumberResult> {
-    if (this.allowOnlyNameOrNumberProperties && left.type !== 'NUMBER' && left.type !== 'NAME') {
-      throw new UnexpectedTypeError(left)
+  parseInfix (parser: ParserEngine, left: IntermediateResult): KeyValueResult | JsdocObjectKeyValueResult {
+    let optional = false
+
+    if (this.allowOptional && left.type === 'NULLABLE') {
+      optional = true
+      left = left.element
     }
-    parser.consume(':')
-    const value = parser.parseType(Precedence.KEY_VALUE)
-    return {
-      type: 'KEY_VALUE',
-      left: left.type === 'NUMBER' ? left : assertTerminal(left),
-      right: value
+
+    if (left.type === 'NUMBER' || left.type === 'NAME' || left.type === 'STRING_VALUE') {
+      parser.consume(':')
+
+      let quote
+      if (left.type === 'STRING_VALUE') {
+        quote = left.meta.quote
+      }
+
+      return {
+        type: 'KEY_VALUE',
+        value: left.value.toString(),
+        right: parser.parseType(Precedence.KEY_VALUE),
+        optional: optional,
+        meta: {
+          quote
+        }
+      }
+    } else {
+      if (!this.allowKeyTypes) {
+        throw new UnexpectedTypeError(left)
+      }
+
+      parser.consume(':')
+
+      return {
+        type: 'JSDOC_OBJECT_KEY_VALUE',
+        left: assertTerminal(left),
+        right: parser.parseType(Precedence.KEY_VALUE)
+      }
     }
   }
 }

--- a/src/parslets/NameParslet.ts
+++ b/src/parslets/NameParslet.ts
@@ -3,45 +3,7 @@ import { TokenType } from '../lexer/Token'
 import { NameResult } from '../ParseResult'
 import { PrefixParslet } from './Parslet'
 import { Precedence } from '../Precedence'
-
-const reservedWords = [
-  'null',
-  'true',
-  'false',
-  'break',
-  'case',
-  'catch',
-  'class',
-  'const',
-  'continue',
-  'debugger',
-  'default',
-  'delete',
-  'do',
-  'else',
-  'export',
-  'extends',
-  'finally',
-  'for',
-  'function',
-  'if',
-  'import',
-  'in',
-  'instanceof',
-  'new',
-  'return',
-  'super',
-  'switch',
-  'this',
-  'throw',
-  'try',
-  'typeof',
-  'var',
-  'void',
-  'while',
-  'with',
-  'yield'
-]
+import { reservedWords } from '../transforms/catharsisTransform'
 
 interface NameParsletOptions {
   allowedAdditionalTokens: TokenType[]

--- a/src/parslets/ObjectParslet.ts
+++ b/src/parslets/ObjectParslet.ts
@@ -3,8 +3,19 @@ import { TokenType } from '../lexer/Token'
 import { ParserEngine } from '../ParserEngine'
 import { ParseResult, ObjectResult } from '../ParseResult'
 import { Precedence } from '../Precedence'
+import { UnexpectedTypeError } from '../errors'
+
+interface ObjectParsletOptions {
+  allowKeyTypes: boolean
+}
 
 export class ObjectParslet implements PrefixParslet {
+  private readonly allowKeyTypes: boolean
+
+  constructor (opts: ObjectParsletOptions) {
+    this.allowKeyTypes = opts.allowKeyTypes
+  }
+
   accepts (type: TokenType): boolean {
     return type === '{'
   }
@@ -22,12 +33,34 @@ export class ObjectParslet implements PrefixParslet {
 
     if (!parser.consume('}')) {
       do {
-        const field = parser.parseIntermediateType(Precedence.OBJECT)
-        if (field.type !== 'NAME' && field.type !== 'NUMBER' && field.type !== 'KEY_VALUE') {
-          throw new Error('records may only contain \'NAME\', \'NUMBER\' or \'KEY_VALUE\' fields.')
+        let field = parser.parseIntermediateType(Precedence.OBJECT)
+
+        let optional = false
+        if (field.type === 'NULLABLE') {
+          optional = true
+          field = field.element
         }
 
-        result.elements.push(field)
+        if (field.type === 'NUMBER' || field.type === 'NAME' || field.type === 'STRING_VALUE') {
+          let quote
+          if (field.type === 'STRING_VALUE') {
+            quote = field.meta.quote
+          }
+
+          result.elements.push({
+            type: 'KEY_VALUE',
+            value: field.value.toString(),
+            right: undefined,
+            optional: optional,
+            meta: {
+              quote
+            }
+          })
+        } else if (field.type === 'KEY_VALUE' || field.type === 'JSDOC_OBJECT_KEY_VALUE') {
+          result.elements.push(field)
+        } else {
+          throw new UnexpectedTypeError(field)
+        }
       } while (parser.consume(','))
       if (!parser.consume('}')) {
         throw new Error('Unterminated record type. Missing \'}\'')

--- a/src/parslets/ParameterListParslet.ts
+++ b/src/parslets/ParameterListParslet.ts
@@ -3,7 +3,7 @@ import { TokenType } from '../lexer/Token'
 import { IntermediateResult, ParameterList, ParserEngine } from '../ParserEngine'
 import { KeyValueResult, ParseResult } from '../ParseResult'
 import { Precedence } from '../Precedence'
-import { assertNamedKeyValueOrTerminal } from '../assertTypes'
+import { assertKeyValueOrTerminal } from '../assertTypes'
 import { NoParsletFoundError } from '../errors'
 
 interface ParameterListParsletOptions {
@@ -27,13 +27,13 @@ export class ParameterListParslet implements InfixParslet {
 
   parseInfix (parser: ParserEngine, left: IntermediateResult): ParameterList {
     const elements: Array<ParseResult|KeyValueResult> = [
-      assertNamedKeyValueOrTerminal(left)
+      assertKeyValueOrTerminal(left)
     ]
     parser.consume(',')
     do {
       try {
         const next = parser.parseIntermediateType(Precedence.PARAMETER_LIST)
-        elements.push(assertNamedKeyValueOrTerminal(next))
+        elements.push(assertKeyValueOrTerminal(next))
       } catch (e) {
         if (this.allowTrailingComma && e instanceof NoParsletFoundError) {
           break

--- a/src/parslets/ParenthesisParslet.ts
+++ b/src/parslets/ParenthesisParslet.ts
@@ -2,7 +2,7 @@ import { PrefixParslet } from './Parslet'
 import { TokenType } from '../lexer/Token'
 import { Precedence } from '../Precedence'
 import { ParameterList, ParserEngine } from '../ParserEngine'
-import { KeyValueResult, ParenthesisResult } from '../ParseResult'
+import { ParenthesisResult } from '../ParseResult'
 import { assertTerminal } from '../assertTypes'
 
 export class ParenthesisParslet implements PrefixParslet {
@@ -27,10 +27,10 @@ export class ParenthesisParslet implements PrefixParslet {
       }
     } else if (result.type === 'PARAMETER_LIST') {
       return result
-    } else if (result.type === 'KEY_VALUE' && result.left.type === 'NAME') {
+    } else if (result.type === 'KEY_VALUE') {
       return {
         type: 'PARAMETER_LIST',
-        elements: [result as KeyValueResult]
+        elements: [result]
       }
     }
     return {

--- a/src/transforms/identityTransformRules.ts
+++ b/src/transforms/identityTransformRules.ts
@@ -1,6 +1,6 @@
 import { TransformRules } from './transform'
 import {
-  FunctionResult,
+  FunctionResult, JsdocObjectKeyValueResult,
   KeyValueResult,
   NameResult,
   NonTerminalResult,
@@ -65,7 +65,7 @@ export function identityTransformRules (): TransformRules<NonTerminalResult> {
 
     OBJECT: (result, transform) => ({
       type: 'OBJECT',
-      elements: result.elements.map(transform) as Array<KeyValueResult<ParseResult | NumberResult> | ParseResult | NumberResult>
+      elements: result.elements.map(transform) as Array<KeyValueResult | JsdocObjectKeyValueResult>
     }),
 
     NUMBER: result => result,
@@ -84,8 +84,10 @@ export function identityTransformRules (): TransformRules<NonTerminalResult> {
 
     KEY_VALUE: (result, transform) => ({
       type: 'KEY_VALUE',
-      left: transform(result.left) as ParseResult,
-      right: transform(result.right) as ParseResult
+      value: result.value,
+      right: result.right === undefined ? undefined : transform(result.right) as ParseResult,
+      optional: result.optional,
+      meta: result.meta
     }),
 
     IMPORT: (result, transform) => ({
@@ -145,6 +147,12 @@ export function identityTransformRules (): TransformRules<NonTerminalResult> {
     PARENTHESIS: (result, transform) => ({
       type: 'PARENTHESIS',
       element: transform(result.element) as ParseResult
+    }),
+
+    JSDOC_OBJECT_KEY_VALUE: (result, transform) => ({
+      type: 'JSDOC_OBJECT_KEY_VALUE',
+      left: transform(result.left) as ParseResult,
+      right: transform(result.right) as ParseResult
     })
   }
 }

--- a/src/transforms/stringify.ts
+++ b/src/transforms/stringify.ts
@@ -60,7 +60,14 @@ export function stringifyRules (): TransformRules<string> {
 
     IMPORT: (result, transform) => `import(${transform(result.element)})`,
 
-    KEY_VALUE: (result, transform) => `${transform(result.left)}: ${transform(result.right)}`,
+    KEY_VALUE: (result, transform) => {
+      const left = `${result.meta.quote ?? ''}${result.value}${result.meta.quote ?? ''}${result.optional ? '?' : ''}`
+      if (result.right === undefined) {
+        return left
+      } else {
+        return left + `: ${transform(result.right)}`
+      }
+    },
 
     SPECIAL_NAME_PATH: result => `${result.specialType}:${result.meta.quote ?? ''}${result.value}${result.meta.quote ?? ''}`,
 
@@ -86,7 +93,9 @@ export function stringifyRules (): TransformRules<string> {
 
     UNKNOWN: () => '?',
 
-    INTERSECTION: (result, transform) => result.elements.map(transform).join(' & ')
+    INTERSECTION: (result, transform) => result.elements.map(transform).join(' & '),
+
+    JSDOC_OBJECT_KEY_VALUE: (result, transform) => `${transform(result.left)}: ${transform(result.right)}`
   }
 }
 

--- a/src/transforms/transform.ts
+++ b/src/transforms/transform.ts
@@ -33,10 +33,10 @@ export function extractSpecialParams (source: FunctionResult): SpecialFunctionPa
   }
 
   for (const param of source.parameters) {
-    if (param.type === 'KEY_VALUE' && param.left.type === 'NAME') {
-      if (param.left.value === 'this') {
+    if (param.type === 'KEY_VALUE' && param.meta.quote === undefined) {
+      if (param.value === 'this') {
         result.this = param.right
-      } else if (param.left.value === 'new') {
+      } else if (param.value === 'new') {
         result.new = param.right
       } else {
         result.params.push(param)

--- a/test/fixtures/catharsis/function-type.ts
+++ b/test/fixtures/catharsis/function-type.ts
@@ -243,14 +243,12 @@ export const functionFixtures: Fixture[] = [
     expected: {
       parameters: [
         {
-          left: {
-            value: 'this',
-            type: 'NAME',
-            meta: {
-              reservedWord: true
-            }
+          value: 'this',
+          meta: {
+            quote: undefined
           },
           type: 'KEY_VALUE',
+          optional: false,
           right: {
             left: {
               left: {
@@ -305,14 +303,12 @@ export const functionFixtures: Fixture[] = [
     expected: {
       parameters: [
         {
-          left: {
-            value: 'this',
-            type: 'NAME',
-            meta: {
-              reservedWord: true
-            }
+          value: 'this',
+          meta: {
+            quote: undefined
           },
           type: 'KEY_VALUE',
+          optional: false,
           right: {
             left: {
               left: {
@@ -376,12 +372,10 @@ export const functionFixtures: Fixture[] = [
       parameters: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'new',
-            meta: {
-              reservedWord: true
-            }
+          optional: false,
+          value: 'new',
+          meta: {
+            quote: undefined
           },
           right: {
             left: {
@@ -438,13 +432,11 @@ export const functionFixtures: Fixture[] = [
       parameters: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'new',
-            meta: {
-              reservedWord: true
-            }
+          optional: false,
+          meta: {
+            quote: undefined
           },
+          value: 'new',
           right: {
             left: {
               left: {
@@ -507,12 +499,10 @@ export const functionFixtures: Fixture[] = [
       parameters: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'new',
-            meta: {
-              reservedWord: true
-            }
+          optional: false,
+          value: 'new',
+          meta: {
+            quote: undefined
           },
           right: {
             left: {
@@ -546,12 +536,10 @@ export const functionFixtures: Fixture[] = [
         },
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'this',
-            meta: {
-              reservedWord: true
-            }
+          optional: false,
+          value: 'this',
+          meta: {
+            quote: undefined
           },
           right: {
             left: {
@@ -757,12 +745,10 @@ export const functionFixtures: Fixture[] = [
         parameters: [
           {
             type: 'KEY_VALUE',
-            left: {
-              type: 'NAME',
-              value: 'new',
-              meta: {
-                reservedWord: true
-              }
+            optional: false,
+            value: 'new',
+            meta: {
+              quote: undefined
             },
             right: {
               type: 'NAME',
@@ -774,12 +760,10 @@ export const functionFixtures: Fixture[] = [
           },
           {
             type: 'KEY_VALUE',
-            left: {
-              type: 'NAME',
-              meta: {
-                reservedWord: true
-              },
-              value: 'this'
+            optional: false,
+            value: 'this',
+            meta: {
+              quote: undefined
             },
             right: {
               type: 'NAME',
@@ -878,12 +862,10 @@ export const functionFixtures: Fixture[] = [
         parameters: [
           {
             type: 'KEY_VALUE',
-            left: {
-              type: 'NAME',
-              value: 'new',
-              meta: {
-                reservedWord: true
-              }
+            optional: false,
+            value: 'new',
+            meta: {
+              quote: undefined
             },
             right: {
               type: 'NAME',
@@ -895,12 +877,10 @@ export const functionFixtures: Fixture[] = [
           },
           {
             type: 'KEY_VALUE',
-            left: {
-              type: 'NAME',
-              meta: {
-                reservedWord: true
-              },
-              value: 'this'
+            optional: false,
+            value: 'this',
+            meta: {
+              quote: undefined
             },
             right: {
               type: 'NAME',
@@ -1155,12 +1135,10 @@ export const functionFixtures: Fixture[] = [
       parameters: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            meta: {
-              reservedWord: true
-            },
-            value: 'this'
+          optional: false,
+          value: 'this',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'NAME',
@@ -1217,12 +1195,13 @@ export const functionFixtures: Fixture[] = [
       parameters: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            meta: {
-              reservedWord: true
-            },
-            value: 'this'
+          optional: false,
+          value: 'this',
+
+          meta: {
+
+            quote: undefined
+
           },
           right: {
             element: {
@@ -1295,12 +1274,10 @@ export const functionFixtures: Fixture[] = [
         parameters: [
           {
             type: 'KEY_VALUE',
-            left: {
-              type: 'NAME',
-              meta: {
-                reservedWord: true
-              },
-              value: 'new'
+            optional: false,
+            value: 'new',
+            meta: {
+              quote: undefined
             },
             right: {
               type: 'NAME',
@@ -1336,12 +1313,10 @@ export const functionFixtures: Fixture[] = [
         parameters: [
           {
             type: 'KEY_VALUE',
-            left: {
-              type: 'NAME',
-              meta: {
-                reservedWord: true
-              },
-              value: 'new'
+            optional: false,
+            value: 'new',
+            meta: {
+              quote: undefined
             },
             right: {
               type: 'NAME',
@@ -1399,12 +1374,10 @@ export const functionFixtures: Fixture[] = [
       parameters: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            meta: {
-              reservedWord: true
-            },
-            value: 'new'
+          optional: false,
+          value: 'new',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'NAME',
@@ -1534,12 +1507,13 @@ export const functionFixtures: Fixture[] = [
       parameters: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            meta: {
-              reservedWord: true
-            },
-            value: 'this'
+          optional: false,
+          value: 'this',
+
+          meta: {
+
+            quote: undefined
+
           },
           right: {
             type: 'NAME',

--- a/test/fixtures/catharsis/jsdoc.ts
+++ b/test/fixtures/catharsis/jsdoc.ts
@@ -760,7 +760,7 @@ export const jsdocFixtures: Fixture[] = [
       type: 'OBJECT',
       elements: [
         {
-          type: 'KEY_VALUE',
+          type: 'JSDOC_OBJECT_KEY_VALUE',
           left: {
             type: 'GENERIC',
             elements: [
@@ -814,7 +814,7 @@ export const jsdocFixtures: Fixture[] = [
       type: 'OBJECT',
       elements: [
         {
-          type: 'KEY_VALUE',
+          type: 'JSDOC_OBJECT_KEY_VALUE',
           left: {
             type: 'PARENTHESIS',
             element: {
@@ -875,12 +875,10 @@ export const jsdocFixtures: Fixture[] = [
       elements: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'undefinedHTML',
-            meta: {
-              reservedWord: false
-            }
+          optional: false,
+          value: 'undefinedHTML',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'PARENTHESIS',
@@ -924,12 +922,10 @@ export const jsdocFixtures: Fixture[] = [
       elements: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'foo',
-            meta: {
-              reservedWord: false
-            }
+          optional: false,
+          value: 'foo',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'FUNCTION',
@@ -961,12 +957,10 @@ export const jsdocFixtures: Fixture[] = [
       elements: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'foo',
-            meta: {
-              reservedWord: false
-            }
+          optional: false,
+          value: 'foo',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'FUNCTION',
@@ -1028,12 +1022,13 @@ export const jsdocFixtures: Fixture[] = [
         parameters: [
           {
             type: 'KEY_VALUE',
-            left: {
-              type: 'NAME',
-              meta: {
-                reservedWord: true
-              },
-              value: 'this'
+            optional: false,
+            value: 'this',
+
+            meta: {
+
+              quote: undefined
+
             },
             right: {
               left: {

--- a/test/fixtures/catharsis/record-type.ts
+++ b/test/fixtures/catharsis/record-type.ts
@@ -28,12 +28,10 @@ export const recordFixtures: Fixture[] = [
       elements: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'myNum',
-            meta: {
-              reservedWord: false
-            }
+          optional: false,
+          value: 'myNum',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'NAME',
@@ -67,12 +65,10 @@ export const recordFixtures: Fixture[] = [
         elements: [
           {
             type: 'KEY_VALUE',
-            left: {
-              type: 'NAME',
-              value: 'myNum',
-              meta: {
-                reservedWord: false
-              }
+            optional: false,
+            value: 'myNum',
+            meta: {
+              quote: undefined
             },
             right: {
               type: 'NAME',
@@ -111,12 +107,10 @@ export const recordFixtures: Fixture[] = [
         elements: [
           {
             type: 'KEY_VALUE',
-            left: {
-              type: 'NAME',
-              value: 'myNum',
-              meta: {
-                reservedWord: false
-              }
+            optional: false,
+            value: 'myNum',
+            meta: {
+              quote: undefined
             },
             right: {
               type: 'NAME',
@@ -154,12 +148,10 @@ export const recordFixtures: Fixture[] = [
         elements: [
           {
             type: 'KEY_VALUE',
-            left: {
-              type: 'NAME',
-              value: 'myNum',
-              meta: {
-                reservedWord: false
-              }
+            optional: false,
+            value: 'myNum',
+            meta: {
+              quote: undefined
             },
             right: {
               type: 'NAME',
@@ -197,12 +189,10 @@ export const recordFixtures: Fixture[] = [
         elements: [
           {
             type: 'KEY_VALUE',
-            left: {
-              type: 'NAME',
-              value: 'myNum',
-              meta: {
-                reservedWord: false
-              }
+            optional: false,
+            value: 'myNum',
+            meta: {
+              quote: undefined
             },
             right: {
               type: 'NAME',
@@ -238,12 +228,10 @@ export const recordFixtures: Fixture[] = [
       elements: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'myNum',
-            meta: {
-              reservedWord: false
-            }
+          optional: false,
+          value: 'myNum',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'NAME',
@@ -254,10 +242,12 @@ export const recordFixtures: Fixture[] = [
           }
         },
         {
-          type: 'NAME',
+          type: 'KEY_VALUE',
           value: 'myObject',
+          right: undefined,
+          optional: false,
           meta: {
-            reservedWord: false
+            quote: undefined
           }
         }
       ]
@@ -282,12 +272,10 @@ export const recordFixtures: Fixture[] = [
       elements: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'myArray',
-            meta: {
-              reservedWord: false
-            }
+          optional: false,
+          value: 'myArray',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'GENERIC',
@@ -336,12 +324,10 @@ export const recordFixtures: Fixture[] = [
       elements: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'myKey',
-            meta: {
-              reservedWord: false
-            }
+          optional: false,
+          value: 'myKey',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'PARENTHESIS',
@@ -395,12 +381,10 @@ export const recordFixtures: Fixture[] = [
       elements: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'continue',
-            meta: {
-              reservedWord: true
-            }
+          optional: false,
+          value: 'continue',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'NAME',
@@ -432,12 +416,10 @@ export const recordFixtures: Fixture[] = [
       elements: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'class',
-            meta: {
-              reservedWord: true
-            }
+          optional: false,
+          value: 'class',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'NAME',
@@ -469,12 +451,10 @@ export const recordFixtures: Fixture[] = [
       elements: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'true',
-            meta: {
-              reservedWord: true
-            }
+          optional: false,
+          value: 'true',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'NAME',
@@ -506,9 +486,10 @@ export const recordFixtures: Fixture[] = [
       elements: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NUMBER',
-            value: 0
+          optional: false,
+          value: '0',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'NAME',

--- a/test/fixtures/catharsis/type-application.ts
+++ b/test/fixtures/catharsis/type-application.ts
@@ -194,12 +194,10 @@ export const genericFixtures: Fixture[] = [
                     elements: [
                       {
                         type: 'KEY_VALUE',
-                        left: {
-                          type: 'NAME',
-                          value: 'myKey',
-                          meta: {
-                            reservedWord: false
-                          }
+                        optional: false,
+                        value: 'myKey',
+                        meta: {
+                          quote: undefined
                         },
                         right: {
                           type: 'NAME',
@@ -251,12 +249,10 @@ export const genericFixtures: Fixture[] = [
                 parameters: [
                   {
                     type: 'KEY_VALUE',
-                    left: {
-                      type: 'NAME',
-                      value: 'new',
-                      meta: {
-                        reservedWord: true
-                      }
+                    optional: false,
+                    value: 'new',
+                    meta: {
+                      quote: undefined
                     },
                     right: {
                       type: 'NAME',
@@ -315,10 +311,12 @@ export const genericFixtures: Fixture[] = [
           type: 'OBJECT',
           elements: [
             {
-              type: 'NAME',
+              type: 'KEY_VALUE',
               value: 'length',
+              right: undefined,
+              optional: false,
               meta: {
-                reservedWord: false
+                quote: undefined
               }
             }
           ]

--- a/test/fixtures/misc/namePaths.ts
+++ b/test/fixtures/misc/namePaths.ts
@@ -1,4 +1,4 @@
-import { Fixture } from './Fixture'
+import { Fixture } from '../Fixture'
 
 export const eventExternalFixtures: Fixture[] = [
   {

--- a/test/fixtures/typescript/arrow-function.ts
+++ b/test/fixtures/typescript/arrow-function.ts
@@ -9,12 +9,10 @@ export const arrowFunctionFixtures: Fixture[] = [
       parameters: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'x',
-            meta: {
-              reservedWord: false
-            }
+          optional: false,
+          value: 'x',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'ANY'
@@ -47,12 +45,10 @@ export const arrowFunctionFixtures: Fixture[] = [
       parameters: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'x',
-            meta: {
-              reservedWord: false
-            }
+          optional: false,
+          value: 'x',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'NAME',
@@ -93,12 +89,10 @@ export const arrowFunctionFixtures: Fixture[] = [
       parameters: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'x',
-            meta: {
-              reservedWord: false
-            }
+          optional: false,
+          value: 'x',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'NAME',
@@ -110,12 +104,10 @@ export const arrowFunctionFixtures: Fixture[] = [
         },
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'y',
-            meta: {
-              reservedWord: false
-            }
+          optional: false,
+          value: 'y',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'NAME',
@@ -127,12 +119,10 @@ export const arrowFunctionFixtures: Fixture[] = [
         },
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'z',
-            meta: {
-              reservedWord: false
-            }
+          optional: false,
+          value: 'z',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'NAME',
@@ -278,12 +268,10 @@ export const arrowFunctionFixtures: Fixture[] = [
       parameters: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'arrow',
-            meta: {
-              reservedWord: false
-            }
+          optional: false,
+          value: 'arrow',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'NAME',
@@ -295,12 +283,10 @@ export const arrowFunctionFixtures: Fixture[] = [
         },
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'with',
-            meta: {
-              reservedWord: true
-            }
+          optional: false,
+          value: 'with',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'NAME',
@@ -447,12 +433,10 @@ export const arrowFunctionFixtures: Fixture[] = [
       parameters: [
         {
           type: 'KEY_VALUE',
-          left: {
-            type: 'NAME',
-            value: 'a',
-            meta: {
-              reservedWord: false
-            }
+          optional: false,
+          value: 'a',
+          meta: {
+            quote: undefined
           },
           right: {
             type: 'NAME',
@@ -468,12 +452,10 @@ export const arrowFunctionFixtures: Fixture[] = [
         parameters: [
           {
             type: 'KEY_VALUE',
-            left: {
-              type: 'NAME',
-              value: 'b',
-              meta: {
-                reservedWord: false
-              }
+            optional: false,
+            value: 'b',
+            meta: {
+              quote: undefined
             },
             right: {
               type: 'NAME',

--- a/test/fixtures/typescript/intersection.ts
+++ b/test/fixtures/typescript/intersection.ts
@@ -176,12 +176,10 @@ export const intersectionFixtures: Fixture[] = [
           parameters: [
             {
               type: 'KEY_VALUE',
-              left: {
-                type: 'NAME',
-                value: 'a',
-                meta: {
-                  reservedWord: false
-                }
+              optional: false,
+              value: 'a',
+              meta: {
+                quote: undefined
               },
               right: {
                 type: 'NAME',

--- a/test/fixtures/typescript/objects.ts
+++ b/test/fixtures/typescript/objects.ts
@@ -1,0 +1,100 @@
+import { Fixture } from '../Fixture'
+
+export const objectsFixtures: Fixture[] = [
+  {
+    description: 'optional entry',
+    input: '{ object?: string, key: string }',
+    stringified: '{object?: string, key: string}',
+    diffExpected: {
+      typescript: {
+        type: 'OBJECT',
+        elements: [
+          {
+            type: 'KEY_VALUE',
+            value: 'object',
+            meta: {
+              quote: undefined
+            },
+            right: {
+              type: 'NAME',
+              value: 'string',
+              meta: {
+                reservedWord: false
+              }
+            },
+            optional: true
+          },
+          {
+            type: 'KEY_VALUE',
+            value: 'key',
+            meta: {
+              quote: undefined
+            },
+            right: {
+              type: 'NAME',
+              value: 'string',
+              meta: {
+                reservedWord: false
+              }
+            },
+            optional: false
+          }
+        ]
+      },
+      jsdoc: {
+        type: 'OBJECT',
+        elements: [
+          {
+            type: 'JSDOC_OBJECT_KEY_VALUE',
+            left: {
+              type: 'NULLABLE',
+              element: {
+                type: 'NAME',
+                value: 'object',
+                meta: {
+                  reservedWord: false
+                }
+              },
+              meta: {
+                position: 'SUFFIX'
+              }
+            },
+            right: {
+              type: 'NAME',
+              value: 'string',
+              meta: {
+                reservedWord: false
+              }
+            }
+          },
+          {
+            type: 'KEY_VALUE',
+            value: 'key',
+            meta: {
+              quote: undefined
+            },
+            right: {
+              type: 'NAME',
+              value: 'string',
+              meta: {
+                reservedWord: false
+              }
+            },
+            optional: false
+          }
+        ]
+      }
+    },
+    modes: ['jsdoc', 'typescript'],
+    catharsis: {
+      closure: 'fail',
+      jsdoc: 'fail' // this seems to be a catharsis error: https://github.com/hegemonic/catharsis/blob/222e8fc4350c346b47ca8395c37512290979df12/lib/parser.pegjs#L555
+    },
+    jtp: {
+      closure: 'differ',
+      jsdoc: 'differ',
+      typescript: 'typescript',
+      permissive: 'typescript'
+    }
+  }
+]

--- a/test/other.spec.ts
+++ b/test/other.spec.ts
@@ -1,6 +1,6 @@
 import 'mocha'
 
-import { eventExternalFixtures } from './fixtures/namePaths'
+import { eventExternalFixtures } from './fixtures/misc/namePaths'
 import { testFixture } from './fixtures/Fixture'
 
 describe('Name paths', () => {

--- a/test/typescript.spec.ts
+++ b/test/typescript.spec.ts
@@ -7,6 +7,7 @@ import { keyofFixtures } from './fixtures/typescript/keyof'
 import { importFixtures } from './fixtures/typescript/import'
 import { arrowFunctionFixtures } from './fixtures/typescript/arrow-function'
 import { intersectionFixtures } from './fixtures/typescript/intersection'
+import { objectsFixtures } from './fixtures/typescript/objects'
 
 describe('TypeScript TypeOf', () => {
   for (const fixture of typeOfFixtures) {
@@ -40,6 +41,12 @@ describe('TypeScript tuples', () => {
 
 describe('TypeScript intersection', () => {
   for (const fixture of intersectionFixtures) {
+    testFixture(fixture)
+  }
+})
+
+describe('TypeScript objects', () => {
+  for (const fixture of objectsFixtures) {
     testFixture(fixture)
   }
 })


### PR DESCRIPTION
BREAKING CHANGE: key `left` was removed from `KEY_VALUE` and is replaced by `value`. For the special record entries of `jsdoc` mode a new type `JSDOC_OBJECT_KEY_VALUE` was introduced.

Fixes: #18