### PR TITLE
fix: Further liberalize id start and continue

### DIFF
--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -39,10 +39,10 @@ function getQuoted (text: string): string|null {
   return text.slice(0, position)
 }
 
-const identifierStartRegex = /[\p{ID_Start}$_]/u;
+const identifierStartRegex = /[\p{ID_Start}$_]/u
 // A hyphen is not technically allowed, but to keep it liberal for now,
 //  adding it here
-const identifierContinueRegex = /[\p{ID_Continue}\u200C\u200D$-]/u;
+const identifierContinueRegex = /[\p{ID_Continue}\u200C\u200D$-]/u
 function getIdentifier (text: string): string|null {
   let char = text[0]
   if (!identifierStartRegex.test(char)) {

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -42,7 +42,7 @@ function getQuoted (text: string): string|null {
 const identifierStartRegex = /[\p{ID_Start}$_]/u
 // A hyphen is not technically allowed, but to keep it liberal for now,
 //  adding it here
-const identifierContinueRegex = /[\p{ID_Continue}\u200C\u200D$-]/u
+const identifierContinueRegex = /[$\-\p{ID_Continue}\u200C\u200D]/u
 function getIdentifier (text: string): string|null {
   let char = text[0]
   if (!identifierStartRegex.test(char)) {

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -39,10 +39,10 @@ function getQuoted (text: string): string|null {
   return text.slice(0, position)
 }
 
-const identifierStartRegex = /\p{ID_Start}/u
+const identifierStartRegex = /[\p{ID_Start}$_]/u;
 // A hyphen is not technically allowed, but to keep it liberal for now,
 //  adding it here
-const identifierContinueRegex = /[\p{ID_Continue}-]/u
+const identifierContinueRegex = /[\p{ID_Continue}\u200C\u200D$-]/u;
 function getIdentifier (text: string): string|null {
   let char = text[0]
   if (!identifierStartRegex.test(char)) {


### PR DESCRIPTION
- Further liberalize id. start to reflect JavaScript start (including $ and _) as well as $ (and _) and zero widths in ID continue