### PR TITLE
support Unicode escape sequences

### DIFF
--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -42,7 +42,7 @@ function getQuoted (text: string): string|null {
 const identifierStartRegex = /[$_\p{ID_Start}]|\\u\p{Hex_Digit}{4}|\\u\{0*(?:\p{Hex_Digit}{1,5}|10\p{Hex_Digit}{4})\}/u
 // A hyphen is not technically allowed, but to keep it liberal for now,
 //  adding it here
-const identifierContinueRegex = /[$\-\p{ID_Continue}\u200C\u200D]|\\u\{0*(?:[a-f\d]{1,5}|10[a-f\d]{4})\}/u
+const identifierContinueRegex = /[$\-\p{ID_Continue}\u200C\u200D]|\\u\p{Hex_Digit}{4}|\\u\{0*(?:\p{Hex_Digit}{1,5}|10\p{Hex_Digit}{4})\}/u
 function getIdentifier (text: string): string|null {
   let char = text[0]
   if (!identifierStartRegex.test(char)) {

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -39,10 +39,10 @@ function getQuoted (text: string): string|null {
   return text.slice(0, position)
 }
 
-const identifierStartRegex = /[\p{ID_Start}$_]/u
+const identifierStartRegex = /[$_\p{ID_Start}]|\\u[a-f\d]{4}|\\u\{[a-f\d]{1,6}\}/u
 // A hyphen is not technically allowed, but to keep it liberal for now,
 //  adding it here
-const identifierContinueRegex = /[$\-\p{ID_Continue}\u200C\u200D]/u
+const identifierContinueRegex = /[$\-\p{ID_Continue}\u200C\u200D]|\\u[a-f\d]{4}|\\u\{[a-f\d]{1,6}\}/u
 function getIdentifier (text: string): string|null {
   let char = text[0]
   if (!identifierStartRegex.test(char)) {

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -39,7 +39,7 @@ function getQuoted (text: string): string|null {
   return text.slice(0, position)
 }
 
-const identifierStartRegex = /[$_\p{ID_Start}]|\\u[a-f\d]{4}|\\u\{0*(?:[a-f\d]{1,5}|10[a-f\d]{4})\}/u
+const identifierStartRegex = /[$_\p{ID_Start}]|\\u\p{Hex_Digit}{4}|\\u\{0*(?:\p{Hex_Digit}{1,5}|10\p{Hex_Digit}{4})\}/u
 // A hyphen is not technically allowed, but to keep it liberal for now,
 //  adding it here
 const identifierContinueRegex = /[$\-\p{ID_Continue}\u200C\u200D]|\\u\{0*(?:[a-f\d]{1,5}|10[a-f\d]{4})\}/u

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -39,10 +39,10 @@ function getQuoted (text: string): string|null {
   return text.slice(0, position)
 }
 
-const identifierStartRegex = /[$_\p{ID_Start}]|\\u[a-f\d]{4}|\\u\{[a-f\d]{1,6}\}/u
+const identifierStartRegex = /[$_\p{ID_Start}]|\\u[a-f\d]{4}|\\u\{0*(?:[a-f\d]{1,5}|10[a-f\d]{4})\}/u
 // A hyphen is not technically allowed, but to keep it liberal for now,
 //  adding it here
-const identifierContinueRegex = /[$\-\p{ID_Continue}\u200C\u200D]|\\u[a-f\d]{4}|\\u\{[a-f\d]{1,6}\}/u
+const identifierContinueRegex = /[$\-\p{ID_Continue}\u200C\u200D]|\\u\{0*(?:[a-f\d]{1,5}|10[a-f\d]{4})\}/u
 function getIdentifier (text: string): string|null {
   let char = text[0]
   if (!identifierStartRegex.test(char)) {


### PR DESCRIPTION
JSDoc mode really shouldn't allow the 6-digit ones at this point (as does this PR), but I imagine that might be seen more as a bug on their part. I filed https://github.com/hegemonic/catharsis/issues/65 . But if you want to instead refactor this PR to accept a mode to determine this production, be my guest--that could be updated later if jsdoc ends up supporting.

Note that although *normal* `HexDigits` supports a numeric separator literal (i.e., `_` as in the recent ES addition allowing for the likes of numbers expressed as `1_234_567` including for hex digits), the reference to `~Sep` in the spec apparently means *not* to support numeric separators (as would be suggested by the fact that https://github.com/tc39/proposal-numeric-separator/issues/25 undid the support, albeit in a different way than this `~Sep` syntax). So we're good not supporting numeric separators as per this PR.