### PR TITLE
Test only

### DIFF
--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -39,10 +39,10 @@ function getQuoted (text: string): string|null {
   return text.slice(0, position)
 }
 
-const identifierStartRegex = /[\p{ID_Start}$_]/u
+const identifierStartRegex = /[$_\p{ID_Start}]|\\u[a-f\d]{4}|\\u\{[a-f\d]{1,6}\}/u
 // A hyphen is not technically allowed, but to keep it liberal for now,
 //  adding it here
-const identifierContinueRegex = /[$\-\p{ID_Continue}\u200C\u200D]/u
+const identifierContinueRegex = /[$\-\p{ID_Continue}\u200C\u200D]|\\u[a-f\d]{4}|\\u\{[a-f\d]{1,6}\}/u
 function getIdentifier (text: string): string|null {
   let char = text[0]
   if (!identifierStartRegex.test(char)) {

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -39,10 +39,10 @@ function getQuoted (text: string): string|null {
   return text.slice(0, position)
 }
 
-const identifierStartRegex = /[$_\p{ID_Start}]|\\u[a-f\d]{4}|\\u\{[a-f\d]{1,6}\}/u
+const identifierStartRegex = /[$_\p{ID_Start}]|\\u[a-f\d]{4}|\\u\{0*(?:[a-f\d]{1,5}|10[a-f\d]{4})\}/u
 // A hyphen is not technically allowed, but to keep it liberal for now,
 //  adding it here
-const identifierContinueRegex = /[$\-\p{ID_Continue}\u200C\u200D]|\\u[a-f\d]{4}|\\u\{[a-f\d]{1,6}\}/u
+const identifierContinueRegex = /[$\-\p{ID_Continue}\u200C\u200D]|\\u\{0*(?:[a-f\d]{1,5}|10[a-f\d]{4})\}/u
 function getIdentifier (text: string): string|null {
   let char = text[0]
   if (!identifierStartRegex.test(char)) {


### PR DESCRIPTION
Builds on #61.

- test: allow individual fixture tests to be treated as `only`

(Just add `only: 1` to an individual fixture)

Also lints per eslint config standard