### PR TITLE
feat: add `JsdocTypeCallSignature`, `JsdocTypeConstructorSignature`, and `JsdocTypeMethodSignature`

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,7 +29,7 @@ export interface PredicateResult {
 2. Run the tests. With `npm test` we do a typecheck (`npm run typecheck`), linting (`npm run lint`) and the unit tests (`npm run test:spec`).
    If we run `npm test` we first see that there are multiple type problems in the transforms.
 
-3. For the `catharsisTransform` and the `jtpTransform` we can simply add `nonAvailableTransform` as these do not support TypeScript
+3. For the `catharsisTransform` and the `jtpTransform` we can simply add `notAvailableTransform` as these do not support TypeScript
    predicates (see the respective files for examples). The `identityTransform` simply needs to return the same type and the
    `stringify` transform should create a valid string output of a given type. These transforms look like this:
 
@@ -88,13 +88,13 @@ describe('typescript predicates', () => {
 })
 ```
 
-6. Add new tokens. If we run the test again we will get an error for our unit test and can actually start developing our
+7. Add new tokens. If we run the test again we will get an error for our unit test and can actually start developing our
    feature. The message is `Error: The parsing ended early. The next token was: 'Identifier' with value 'is'`. It tells us
    that the lexer was not able to parse `is` as a token, but treats it as an identifier. To fix this we add `'is'` to
    the `TokenType` in `src/lexer/Token.ts` and create a new lexing rule in `src/lexer/Lexer.ts`. As this is just a static
    text token, we can just add `makeKeyWordRule('is')` to the `rules` array.
 
-7. Add a parslet. The next error is `Error: The parsing ended early. The next token was: 'is' with value 'is'`, which
+8. Add a parslet. The next error is `Error: The parsing ended early. The next token was: 'is' with value 'is'`, which
    tells us that a parslet is missing. We create a new file `src/parslets/predicateParslet.ts` and use `composeParslet` to
    create a parslet.
 
@@ -105,7 +105,7 @@ export const predicateParslet = composeParslet({
   name: 'predicateParslet'
 })
 ```
-8. Decide if it is a prefix or infix parslet (postfix are also infix parslets). The token we recognize is the `is`. As
+9. Decide if it is a prefix or infix parslet (postfix are also infix parslets). The token we recognize is the `is`. As
    this is syntactically an infix operator we can use the `parseInfix` parameter of `composeParslet`. Also we need to add
    the `accept` parameter to indicate that we accept tokens of type `is`. For infix parslets we also need to specify the
    precedence which could be explained as the 'binding strength' of the infix operator. For now we will just choose
@@ -125,7 +125,7 @@ export const predicateParslet = composeParslet({
 })
 ```
 
-9. Implement `parseInfix`. Here `parser` is the currently used parser and `left` is the already parsed part. So we ensure
+10. Implement `parseInfix`. Here `parser` is the currently used parser and `left` is the already parsed part. So we ensure
    that `left` is indeed a name. If that is the case we can now safely `consume` the `is` token. With this we tell the parser
    that we can continue parsing the next token and then proceed to assemble the AST and recursively continue parsing the `right` part of our
    expression. To ensure that we indeed get a `RootResult` for our right expression we can use the function `assertRoot`.
@@ -158,10 +158,12 @@ export const predicateParslet = composeParslet({
 })
 ```
 
-10. Add parslet to grammar. Now we need to tell the parser that we actually want to use this parslet. For this we add
+11. Add parslet to grammar. Now we need to tell the parser that we actually want to use this parslet. For this we add
     the parslet to the `typescriptGrammar` array in `src/grammars/typescriptGrammar.ts`.
 
-11. Run tests and debug until done. In the end we see that all tests pass, and we are done. We can now add some more tests
-    if we like.
+12. Run tests and debug until done. In the end we see that all tests pass, and we are done. We can now add some more tests
+    if we like. If you want to run tests on just a particular file, you can temporarily
+    rename the file, e.g., to have the ending `.spec1.ts` and then temporarily
+    target "spec1" in `.mocharc.json`.
 
-12. If there are any problems with this guide, feel free to open an issue!
+13. If there are any problems with this guide, feel free to open an issue!

--- a/src/assertTypes.ts
+++ b/src/assertTypes.ts
@@ -15,7 +15,8 @@ export function assertRootResult (result?: IntermediateResult): RootResult {
     result.type === 'JsdocTypeProperty' || result.type === 'JsdocTypeReadonlyProperty' ||
     result.type === 'JsdocTypeObjectField' || result.type === 'JsdocTypeJsdocObjectField' ||
     result.type === 'JsdocTypeIndexSignature' || result.type === 'JsdocTypeMappedType' ||
-    result.type === 'JsdocTypeTypeParameter'
+    result.type === 'JsdocTypeTypeParameter' || result.type === 'JsdocTypeCallSignature' ||
+    result.type === 'JsdocTypeConstructorSignature' || result.type === 'JsdocTypeMethodSignature'
   ) {
     throw new UnexpectedTypeError(result)
   }

--- a/src/grammars/typescriptGrammar.ts
+++ b/src/grammars/typescriptGrammar.ts
@@ -9,6 +9,7 @@ import { stringValueParslet } from '../parslets/StringValueParslet'
 import { numberParslet } from '../parslets/NumberParslet'
 import { createFunctionParslet } from '../parslets/FunctionParslet'
 import { createObjectParslet } from '../parslets/ObjectParslet'
+import { functionPropertyParslet } from '../parslets/FunctionPropertyParslet'
 import { createTupleParslet } from '../parslets/TupleParslet'
 import { createVariadicParslet } from '../parslets/VariadicParslet'
 import { typeOfParslet } from '../parslets/TypeOfParslet'
@@ -29,6 +30,7 @@ import { readonlyArrayParslet } from '../parslets/ReadonlyArrayParslet'
 import { conditionalParslet } from '../parslets/ConditionalParslet'
 
 const objectFieldGrammar: Grammar = [
+  functionPropertyParslet,
   readonlyPropertyParslet,
   createNameParslet({
     allowedAdditionalTokens: ['typeof', 'module', 'keyof', 'event', 'external', 'in']
@@ -50,7 +52,14 @@ export const typescriptGrammar: Grammar = [
   ...baseGrammar,
   createObjectParslet({
     allowKeyTypes: false,
-    objectFieldGrammar
+    objectFieldGrammar,
+    signatureGrammar: [
+      createKeyValueParslet({
+        allowVariadic: true,
+        allowOptional: true,
+        acceptParameterList: true,
+      })
+    ]
   }),
   readonlyArrayParslet,
   typeOfParslet,
@@ -94,3 +103,4 @@ export const typescriptGrammar: Grammar = [
     allowOptional: true
   })
 ]
+

--- a/src/parslets/FunctionPropertyParslet.ts
+++ b/src/parslets/FunctionPropertyParslet.ts
@@ -1,0 +1,75 @@
+import { composeParslet } from './Parslet'
+import type { CallSignatureResult, ConstructorSignatureResult, MethodSignatureResult } from '../result/NonRootResult'
+import type { NameResult } from '../result/RootResult'
+
+// (optional new or optionally quoted other optional name) +
+//    (...args) + ":" + return value
+export const functionPropertyParslet = composeParslet({
+  name: 'functionPropertyParslet',
+  accept: (type, next) =>
+    type === 'new' && next ==='(' ||
+    type === 'Identifier' && next === '(' ||
+    type === 'StringValue' && next === '(' ||
+    type === '(',
+  parsePrefix: parser => {
+    let result: CallSignatureResult | ConstructorSignatureResult | MethodSignatureResult
+
+    // Just a placeholder
+    const returnType: NameResult = {
+      type: 'JsdocTypeName',
+      value: 'void'
+    }
+
+    const newKeyword = parser.consume('new')
+    if (newKeyword) {
+      result = {
+        type: 'JsdocTypeConstructorSignature',
+        parameters: [],
+        returnType
+      }
+    } else {
+      const text = parser.lexer.current.text
+      const identifier = parser.consume('Identifier')
+      if (identifier) {
+        result = {
+          type: 'JsdocTypeMethodSignature',
+          name: text,
+          meta: {
+            quote: undefined
+          },
+          parameters: [],
+          returnType
+        }
+      } else {
+        const text = parser.lexer.current.text
+        const stringValue = parser.consume('StringValue')
+        if (stringValue) {
+          result = {
+            type: 'JsdocTypeMethodSignature',
+            name: text.slice(1, -1),
+            meta: {
+              quote: text.startsWith('"') ? 'double' : 'single'
+            },
+            parameters: [],
+            returnType
+          }
+        } else {
+          result = {
+            type: 'JsdocTypeCallSignature',
+            parameters: [],
+            returnType
+          }
+        }
+      }
+    }
+
+    const hasParenthesis = parser.lexer.current.type === '('
+
+    /* c8 ignore next 3 -- Unreachable */
+    if (!hasParenthesis) {
+      throw new Error('function property is missing parameter list')
+    }
+
+    return result
+  }
+})

--- a/src/parslets/KeyValueParslet.ts
+++ b/src/parslets/KeyValueParslet.ts
@@ -2,9 +2,10 @@ import { composeParslet, type ParsletFunction } from './Parslet'
 import { Precedence } from '../Precedence'
 import { UnexpectedTypeError } from '../errors'
 
-export function createKeyValueParslet ({ allowOptional, allowVariadic }: {
+export function createKeyValueParslet ({ allowOptional, allowVariadic, acceptParameterList }: {
   allowOptional: boolean
-  allowVariadic: boolean
+  allowVariadic: boolean,
+  acceptParameterList?: boolean
 }): ParsletFunction {
   return composeParslet({
     name: 'keyValueParslet',
@@ -25,6 +26,10 @@ export function createKeyValueParslet ({ allowOptional, allowVariadic }: {
       }
 
       if (left.type !== 'JsdocTypeName') {
+        if (acceptParameterList !== undefined && left.type === 'JsdocTypeParameterList') {
+          parser.consume(':')
+          return left
+        }
         throw new UnexpectedTypeError(left)
       }
 

--- a/src/result/NonRootResult.ts
+++ b/src/result/NonRootResult.ts
@@ -16,6 +16,10 @@ export type NonRootResult =
   | MappedTypeResult
   | IndexSignatureResult
   | TypeParameterResult
+  | CallSignatureResult
+  | ConstructorSignatureResult
+  | MethodSignatureResult
+
 
 export interface ObjectFieldResult {
   type: 'JsdocTypeObjectField'
@@ -71,4 +75,26 @@ export interface TypeParameterResult {
   defaultValue?: RootResult
   name: NameResult
   constraint?: RootResult
+}
+
+export interface CallSignatureResult {
+  type: 'JsdocTypeCallSignature'
+  parameters: Array<RootResult | KeyValueResult>
+  returnType: RootResult
+}
+
+export interface ConstructorSignatureResult {
+  type: 'JsdocTypeConstructorSignature'
+  parameters: Array<RootResult | KeyValueResult>
+  returnType: RootResult
+}
+
+export interface MethodSignatureResult {
+  type: 'JsdocTypeMethodSignature'
+  name: string
+  meta: {
+    quote: QuoteStyle | undefined
+  }
+  parameters: Array<RootResult | KeyValueResult>
+  returnType: RootResult
 }

--- a/src/result/RootResult.ts
+++ b/src/result/RootResult.ts
@@ -3,7 +3,10 @@ import type {
   KeyValueResult,
   ObjectFieldResult,
   PropertyResult,
-  TypeParameterResult
+  TypeParameterResult,
+  CallSignatureResult,
+  ConstructorSignatureResult,
+  MethodSignatureResult
 } from './NonRootResult'
 
 /**
@@ -188,7 +191,7 @@ export interface FunctionResult {
  */
 export interface ObjectResult {
   type: 'JsdocTypeObject'
-  elements: Array<ObjectFieldResult | JsdocObjectFieldResult>
+  elements: Array<ObjectFieldResult | JsdocObjectFieldResult | CallSignatureResult | ConstructorSignatureResult | MethodSignatureResult>
   meta: {
     separator: 'comma' | 'semicolon' | 'linebreak' | 'comma-and-linebreak' | 'semicolon-and-linebreak' | undefined
     separatorForSingleObjectField?: boolean

--- a/src/transforms/catharsisTransform.ts
+++ b/src/transforms/catharsisTransform.ts
@@ -318,7 +318,10 @@ const catharsisTransformRules: TransformRules<CatharsisParseResult> = {
   JsdocTypeReadonlyArray: notAvailableTransform,
   JsdocTypeAssertsPlain: notAvailableTransform,
   JsdocTypeConditional: notAvailableTransform,
-  JsdocTypeTypeParameter: notAvailableTransform
+  JsdocTypeTypeParameter: notAvailableTransform,
+  JsdocTypeCallSignature: notAvailableTransform,
+  JsdocTypeConstructorSignature: notAvailableTransform,
+  JsdocTypeMethodSignature: notAvailableTransform
 }
 
 export function catharsisTransform (result: RootResult): CatharsisParseResult {

--- a/src/transforms/identityTransformRules.ts
+++ b/src/transforms/identityTransformRules.ts
@@ -3,7 +3,10 @@ import type {
   JsdocObjectFieldResult,
   KeyValueResult,
   NonRootResult,
-  ObjectFieldResult
+  ObjectFieldResult,
+  CallSignatureResult,
+  ConstructorSignatureResult,
+  MethodSignatureResult
 } from '../result/NonRootResult'
 import type {
   FunctionResult,
@@ -72,7 +75,7 @@ export function identityTransformRules (): TransformRules<NonRootResult> {
       meta: {
         separator: 'comma'
       },
-      elements: result.elements.map(transform) as Array<ObjectFieldResult | JsdocObjectFieldResult>
+      elements: result.elements.map(transform) as Array<ObjectFieldResult | JsdocObjectFieldResult | CallSignatureResult | ConstructorSignatureResult | MethodSignatureResult>
     }),
 
     JsdocTypeNumber: result => result,
@@ -221,6 +224,26 @@ export function identityTransformRules (): TransformRules<NonRootResult> {
       name: transform(result.name) as NameResult,
       constraint: result.constraint !== undefined ? transform(result.constraint) as RootResult : undefined,
       defaultValue: result.defaultValue !== undefined ? transform(result.defaultValue) as RootResult : undefined
+    }),
+
+    JsdocTypeCallSignature: (result, transform) => ({
+      type: 'JsdocTypeCallSignature',
+      parameters: result.parameters.map(transform) as RootResult[],
+      returnType: transform(result.returnType) as RootResult
+    }),
+
+    JsdocTypeConstructorSignature: (result, transform) => ({
+      type: 'JsdocTypeConstructorSignature',
+      parameters: result.parameters.map(transform) as RootResult[],
+      returnType: transform(result.returnType) as RootResult
+    }),
+
+    JsdocTypeMethodSignature: (result, transform) => ({
+      type: 'JsdocTypeMethodSignature',
+      name: result.name,
+      parameters: result.parameters.map(transform) as RootResult[],
+      returnType: transform(result.returnType) as RootResult,
+      meta: result.meta
     })
   }
 }

--- a/src/transforms/jtpTransform.ts
+++ b/src/transforms/jtpTransform.ts
@@ -533,7 +533,13 @@ const jtpRules: TransformRules<JtpResult> = {
 
   JsdocTypeConditional: notAvailableTransform,
 
-  JsdocTypeTypeParameter: notAvailableTransform
+  JsdocTypeTypeParameter: notAvailableTransform,
+
+  JsdocTypeCallSignature: notAvailableTransform,
+
+  JsdocTypeConstructorSignature: notAvailableTransform,
+
+  JsdocTypeMethodSignature: notAvailableTransform
 }
 
 export function jtpTransform (result: RootResult): JtpResult {

--- a/src/transforms/stringify.ts
+++ b/src/transforms/stringify.ts
@@ -218,7 +218,33 @@ export function stringifyRules (): TransformRules<string> {
         result.constraint !== undefined ? ` extends ${transform(result.constraint)}` : ''
       }${
         result.defaultValue !== undefined ? ` = ${transform(result.defaultValue)}` : ''
+      }`,
+
+    JsdocTypeCallSignature: (result, transform) => `(${
+      result.parameters.map(transform).join(', ')
+    }): ${
+      transform(result.returnType)
+    }`,
+
+    JsdocTypeConstructorSignature: (result, transform) => `new (${
+      result.parameters.map(transform).join(', ')
+    }): ${
+      transform(result.returnType)
+    }`,
+
+    JsdocTypeMethodSignature: (result, transform) => {
+      const quote = result.meta.quote === 'double'
+        ? '"'
+        : result.meta.quote === 'single'
+          ? "'"
+          : '';
+
+      return `${quote}${result.name}${quote}(${
+        result.parameters.map(transform).join(', ')
+      }): ${
+        transform(result.returnType)
       }`
+    }
   }
 }
 

--- a/src/visitorKeys.ts
+++ b/src/visitorKeys.ts
@@ -40,5 +40,8 @@ export const visitorKeys: VisitorKeys = {
   JsdocTypeReadonlyArray: ['element'],
   JsdocTypeAssertsPlain: ['element'],
   JsdocTypeConditional: ['checksType', 'extendsType', 'trueType', 'falseType'],
-  JsdocTypeTypeParameter: ['name', 'constraint', 'defaultValue']
+  JsdocTypeTypeParameter: ['name', 'constraint', 'defaultValue'],
+  JsdocTypeCallSignature: ['parameters', 'returnType'],
+  JsdocTypeConstructorSignature: ['parameters', 'returnType'],
+  JsdocTypeMethodSignature: ['parameters', 'returnType']
 }

--- a/test/fixtures/typescript/callSignature.spec.ts
+++ b/test/fixtures/typescript/callSignature.spec.ts
@@ -1,0 +1,47 @@
+import { testFixture } from '../Fixture'
+
+describe('typescript call signatures', () => {
+  describe('should parse a call signature', () => {
+    testFixture({
+      input: '{(a: string, b: number): SomeType}',
+      modes: ['typescript'],
+      expected: {
+        type: 'JsdocTypeObject',
+        meta: {
+          separator: 'comma'
+        },
+        elements: [
+          {
+            type: 'JsdocTypeCallSignature',
+            parameters: [
+              {
+                type: 'JsdocTypeKeyValue',
+                key: 'a',
+                right: {
+                  type: 'JsdocTypeName',
+                  value: 'string'
+                },
+                optional: false,
+                variadic: false
+              },
+              {
+                type: 'JsdocTypeKeyValue',
+                key: 'b',
+                right: {
+                  type: 'JsdocTypeName',
+                  value: 'number'
+                },
+                optional: false,
+                variadic: false
+              }
+            ],
+            returnType: {
+              type: 'JsdocTypeName',
+              value: 'SomeType'
+            }
+          }
+        ]
+      }
+    })
+  })
+})

--- a/test/fixtures/typescript/constructorSignature.spec.ts
+++ b/test/fixtures/typescript/constructorSignature.spec.ts
@@ -1,0 +1,94 @@
+import { testFixture } from '../Fixture'
+
+describe('typescript constructor signatures', () => {
+  describe('should parse a constructor signature', () => {
+    testFixture({
+      input: '{new (a: string, b: number): SomeType}',
+      modes: ['typescript'],
+      expected: {
+        type: 'JsdocTypeObject',
+        meta: {
+          separator: 'comma'
+        },
+        elements: [
+          {
+            type: 'JsdocTypeConstructorSignature',
+            parameters: [
+              {
+                type: 'JsdocTypeKeyValue',
+                key: 'a',
+                right: {
+                  type: 'JsdocTypeName',
+                  value: 'string'
+                },
+                optional: false,
+                variadic: false
+              },
+              {
+                type: 'JsdocTypeKeyValue',
+                key: 'b',
+                right: {
+                  type: 'JsdocTypeName',
+                  value: 'number'
+                },
+                optional: false,
+                variadic: false
+              }
+            ],
+            returnType: {
+              type: 'JsdocTypeName',
+              value: 'SomeType'
+            }
+          }
+        ]
+      }
+    })
+  })
+
+  describe('should parse a constructor signature', () => {
+    testFixture({
+      input: '{new (...args: any[]): object}',
+      modes: ['typescript'],
+      expected: {
+        type: 'JsdocTypeObject',
+        meta: {
+          separator: 'comma'
+        },
+        elements: [
+          {
+            type: 'JsdocTypeConstructorSignature',
+            parameters: [
+              {
+                type: 'JsdocTypeKeyValue',
+                key: 'args',
+                right: {
+                  elements: [
+                    {
+                      type: 'JsdocTypeName',
+                      value: 'any'
+                    }
+                  ],
+                  left: {
+                    type: 'JsdocTypeName',
+                    value: 'Array'
+                  },
+                  meta: {
+                    brackets: 'square',
+                    dot: false
+                  },
+                  type: 'JsdocTypeGeneric'
+                },
+                optional: false,
+                variadic: true
+              }
+            ],
+            returnType: {
+              type: 'JsdocTypeName',
+              value: 'object'
+            }
+          }
+        ]
+      }
+    })
+  })
+})

--- a/test/fixtures/typescript/methodSignature.spec.ts
+++ b/test/fixtures/typescript/methodSignature.spec.ts
@@ -1,0 +1,147 @@
+import { testFixture } from '../Fixture'
+
+describe('typescript method signatures', () => {
+  describe('should parse a method signature', () => {
+    testFixture({
+      input: '{someName(a: string, b: number): SomeType}',
+      modes: ['typescript'],
+      expected: {
+        type: 'JsdocTypeObject',
+        meta: {
+          separator: 'comma'
+        },
+        elements: [
+          {
+            type: 'JsdocTypeMethodSignature',
+            name: 'someName',
+            meta: {
+              quote: undefined
+            },
+            parameters: [
+              {
+                type: 'JsdocTypeKeyValue',
+                key: 'a',
+                right: {
+                  type: 'JsdocTypeName',
+                  value: 'string'
+                },
+                optional: false,
+                variadic: false
+              },
+              {
+                type: 'JsdocTypeKeyValue',
+                key: 'b',
+                right: {
+                  type: 'JsdocTypeName',
+                  value: 'number'
+                },
+                optional: false,
+                variadic: false
+              }
+            ],
+            returnType: {
+              type: 'JsdocTypeName',
+              value: 'SomeType'
+            }
+          }
+        ]
+      }
+    })
+  })
+
+  describe('should parse a method signature with double quotes', () => {
+    testFixture({
+      input: '{"new"(a: string, b: number): SomeType}',
+      modes: ['typescript'],
+      expected: {
+        type: 'JsdocTypeObject',
+        meta: {
+          separator: 'comma'
+        },
+        elements: [
+          {
+            type: 'JsdocTypeMethodSignature',
+            name: 'new',
+            meta: {
+              quote: "double"
+            },
+            parameters: [
+              {
+                type: 'JsdocTypeKeyValue',
+                key: 'a',
+                right: {
+                  type: 'JsdocTypeName',
+                  value: 'string'
+                },
+                optional: false,
+                variadic: false
+              },
+              {
+                type: 'JsdocTypeKeyValue',
+                key: 'b',
+                right: {
+                  type: 'JsdocTypeName',
+                  value: 'number'
+                },
+                optional: false,
+                variadic: false
+              }
+            ],
+            returnType: {
+              type: 'JsdocTypeName',
+              value: 'SomeType'
+            }
+          }
+        ]
+      }
+    })
+  })
+
+  describe('should parse a method signature with single quotes', () => {
+    testFixture({
+      input: "{'some-method'(a: string, b: number): SomeType}",
+      modes: ['typescript'],
+      expected: {
+        type: 'JsdocTypeObject',
+        meta: {
+          separator: 'comma'
+        },
+        elements: [
+          {
+            type: 'JsdocTypeMethodSignature',
+            name: 'some-method',
+            meta: {
+              quote: "single"
+            },
+            parameters: [
+              {
+                type: 'JsdocTypeKeyValue',
+                key: 'a',
+                right: {
+                  type: 'JsdocTypeName',
+                  value: 'string'
+                },
+                optional: false,
+                variadic: false
+              },
+              {
+                type: 'JsdocTypeKeyValue',
+                key: 'b',
+                right: {
+                  type: 'JsdocTypeName',
+                  value: 'number'
+                },
+                optional: false,
+                variadic: false
+              }
+            ],
+            returnType: {
+              type: 'JsdocTypeName',
+              value: 'SomeType'
+            }
+          }
+        ]
+      }
+    })
+  })
+})


### PR DESCRIPTION
feat: add `JsdocTypeCallSignature`, `JsdocTypeConstructorSignature`, and `JsdocTypeMethodSignature`

fixes #131