### PR TITLE
feat: allow `infer` in other positions in generic argument lists

### DIFF
--- a/src/result/RootResult.ts
+++ b/src/result/RootResult.ts
@@ -36,6 +36,7 @@ export interface BaseNode extends Range, Location {}
  */
 export type RootResult =
   NameResult
+  | InferResult
   | UnionResult
   | GenericResult
   | StringValueResult
@@ -124,6 +125,16 @@ export interface NameResult extends BaseNode {
 }
 
 /**
+ * A TypeScript `infer` type parameter within a generic argument list.
+ * Represents the `infer X` construct when it appears as a generic argument
+ * (e.g. `Map<any, infer V>`) or alongside other parameters.
+ */
+export interface InferResult extends BaseNode {
+  type: 'JsdocTypeInfer'
+  element: NameResult
+}
+
+/**
  * A type union.
  */
 export interface UnionResult extends BaseNode {
@@ -145,7 +156,6 @@ export interface GenericResult extends BaseNode {
   type: 'JsdocTypeGeneric'
   left: RootResult
   elements: RootResult[]
-  infer?: boolean
   meta: {
     brackets: 'angle' | 'square'
     dot: boolean,

--- a/src/transforms/catharsisTransform.ts
+++ b/src/transforms/catharsisTransform.ts
@@ -312,6 +312,7 @@ const catharsisTransformRules: TransformRules<CatharsisParseResult> = {
 
   JsdocTypeMappedType: notAvailableTransform,
   JsdocTypeIndexSignature: notAvailableTransform,
+  JsdocTypeInfer: notAvailableTransform,
   JsdocTypeImport: notAvailableTransform,
   JsdocTypeKeyof: notAvailableTransform,
   JsdocTypeTuple: notAvailableTransform,

--- a/src/transforms/identityTransformRules.ts
+++ b/src/transforms/identityTransformRules.ts
@@ -150,6 +150,11 @@ export function identityTransformRules (): TransformRules<NonRootResult> {
 
     JsdocTypeName: result => result,
 
+    JsdocTypeInfer: (result, transform) => ({
+      type: 'JsdocTypeInfer',
+      element: transform(result.element) as NameResult
+    }),
+
     JsdocTypeFunction: (result, transform) => {
       const transformed: FunctionResult = {
         type: 'JsdocTypeFunction',

--- a/src/transforms/jtpTransform.ts
+++ b/src/transforms/jtpTransform.ts
@@ -530,6 +530,8 @@ const jtpRules: TransformRules<JtpResult> = {
 
   JsdocTypeIndexSignature: notAvailableTransform,
 
+  JsdocTypeInfer: notAvailableTransform,
+
   JsdocTypeAsserts: notAvailableTransform,
 
   JsdocTypeReadonlyArray: notAvailableTransform,

--- a/src/transforms/stringify.ts
+++ b/src/transforms/stringify.ts
@@ -62,6 +62,8 @@ export function stringifyRules ({
 
     JsdocTypeName: result => result.value,
 
+    JsdocTypeInfer: (result, transform) => `infer ${transform(result.element)}`,
+
     JsdocTypeTuple: (result, transform) => `[${(result.elements as NonRootResult[]).map(transform).join(',' + (result.meta?.elementSpacing ?? ' '))}]`,
 
     JsdocTypeVariadic: (result, transform) => result.meta.position === undefined
@@ -97,7 +99,7 @@ export function stringifyRules ({
           return `${transformed}[]`
         }
       } else {
-        return `${transform(result.left)}${result.meta.dot ? '.' : ''}<${result.infer === true ? 'infer ' : ''}${result.elements.map(transform).join(',' + (result.meta.elementSpacing ?? ' '))}>`
+        return `${transform(result.left)}${result.meta.dot ? '.' : ''}<${result.elements.map(transform).join(',' + (result.meta.elementSpacing ?? ' '))}>`
       }
     },
 

--- a/src/visitorKeys.ts
+++ b/src/visitorKeys.ts
@@ -15,6 +15,7 @@ export const visitorKeys: VisitorKeys = {
   JsdocTypeKeyValue: ['right'],
   JsdocTypeMappedType: ['right'],
   JsdocTypeName: [],
+  JsdocTypeInfer: ['element'],
   JsdocTypeNamePath: ['left', 'right'],
   JsdocTypeNotNullable: ['element'],
   JsdocTypeNull: [],

--- a/test/fixtures/typescript/conditional.spec.ts
+++ b/test/fixtures/typescript/conditional.spec.ts
@@ -43,11 +43,13 @@ describe('typescript conditional', () => {
             type: 'JsdocTypeName',
             value: 'B'
           },
-          infer: true,
           elements: [
             {
-              type: 'JsdocTypeName',
-              value: 'b'
+              type: 'JsdocTypeInfer',
+              element: {
+                type: 'JsdocTypeName',
+                value: 'b'
+              }
             }
           ],
           meta: {
@@ -63,6 +65,28 @@ describe('typescript conditional', () => {
           type: 'JsdocTypeName',
           value: 'C'
         }
+      }
+    })
+  })
+
+  describe('should support `infer` in a non-initial generic parameter', () => {
+    testFixture({
+      input: 'T extends Map<any, infer V> ? V : never',
+      modes: ['typescript'],
+      expected: {
+        type: 'JsdocTypeConditional',
+        checksType: { type: 'JsdocTypeName', value: 'T' },
+        extendsType: {
+          type: 'JsdocTypeGeneric',
+          left: { type: 'JsdocTypeName', value: 'Map' },
+          elements: [
+            { type: 'JsdocTypeName', value: 'any' },
+            { type: 'JsdocTypeInfer', element: { type: 'JsdocTypeName', value: 'V' } }
+          ],
+          meta: { brackets: 'angle', dot: false }
+        },
+        trueType: { type: 'JsdocTypeName', value: 'V' },
+        falseType: { type: 'JsdocTypeName', value: 'never' }
       }
     })
   })
@@ -83,11 +107,13 @@ describe('typescript conditional', () => {
             type: 'JsdocTypeName',
             value: 'B'
           },
-          infer: true,
           elements: [
             {
-              type: 'JsdocTypeName',
-              value: 'b'
+              type: 'JsdocTypeInfer',
+              element: {
+                type: 'JsdocTypeName',
+                value: 'b'
+              }
             }
           ],
           meta: {


### PR DESCRIPTION
feat: allow `infer` in other positions in generic argument lists

BREAKING CHANGE:

Removes infer: boolean from generics in favor of a root level InferResult