### PR TITLE
fix: parse nested indexed access in TypeScript conditional and name-path expressions

### DIFF
--- a/src/parslets/NamePathParslet.ts
+++ b/src/parslets/NamePathParslet.ts
@@ -48,7 +48,11 @@ export function createNamePathParslet ({ allowSquareBracketsOnAnyType, allowJsdo
         ? new Parser(pathGrammar, parser.lexer, parser)
         : parser
 
-    const parsed = pathParser.parseType(Precedence.NAME_PATH)
+    const parsed = pathParser.parseType(
+      brackets && allowSquareBracketsOnAnyType
+        ? Precedence.ALL
+        : Precedence.NAME_PATH
+    )
     parser.acceptLexerState(pathParser)
     let right: PropertyResult | SpecialNamePath<'event'> | IndexedAccessIndexResult
 

--- a/test/fixtures/typescript/conditional.spec.ts
+++ b/test/fixtures/typescript/conditional.spec.ts
@@ -131,6 +131,92 @@ describe('typescript conditional', () => {
     })
   })
 
+  describe('should parse nested indexed access in the true branch', () => {
+    testFixture({
+      input: 'T extends [keyof HTMLElementTagNameMap, any?, any?, any?] ? HTMLElementTagNameMap[T[0]] : JamilihReturn',
+      modes: ['typescript'],
+      expected: {
+        type: 'JsdocTypeConditional',
+        checksType: {
+          type: 'JsdocTypeName',
+          value: 'T'
+        },
+        extendsType: {
+          type: 'JsdocTypeTuple',
+          elements: [
+            {
+              type: 'JsdocTypeKeyof',
+              element: {
+                type: 'JsdocTypeName',
+                value: 'HTMLElementTagNameMap'
+              }
+            },
+            {
+              type: 'JsdocTypeNullable',
+              element: {
+                type: 'JsdocTypeName',
+                value: 'any'
+              },
+              meta: {
+                position: 'suffix'
+              }
+            },
+            {
+              type: 'JsdocTypeNullable',
+              element: {
+                type: 'JsdocTypeName',
+                value: 'any'
+              },
+              meta: {
+                position: 'suffix'
+              }
+            },
+            {
+              type: 'JsdocTypeNullable',
+              element: {
+                type: 'JsdocTypeName',
+                value: 'any'
+              },
+              meta: {
+                position: 'suffix'
+              }
+            }
+          ]
+        },
+        trueType: {
+          type: 'JsdocTypeNamePath',
+          left: {
+            type: 'JsdocTypeName',
+            value: 'HTMLElementTagNameMap'
+          },
+          right: {
+            type: 'JsdocTypeIndexedAccessIndex',
+            right: {
+              type: 'JsdocTypeNamePath',
+              left: {
+                type: 'JsdocTypeName',
+                value: 'T'
+              },
+              right: {
+                type: 'JsdocTypeProperty',
+                value: '0',
+                meta: {
+                  quote: undefined
+                }
+              },
+              pathType: 'property-brackets'
+            }
+          },
+          pathType: 'property-brackets'
+        },
+        falseType: {
+          type: 'JsdocTypeName',
+          value: 'JamilihReturn'
+        }
+      }
+    })
+  })
+
   describe('should throw with bad `infer` within a conditional', () => {
     testFixture({
       input: 'A extends B<infer 5> ? b : C',

--- a/test/fixtures/typescript/namePath.ts
+++ b/test/fixtures/typescript/namePath.ts
@@ -35,4 +35,37 @@ describe('typescript array access test', () => {
       }
     })
   })
+
+  describe('array access with nested indexed access expression', () => {
+    testFixture({
+      input: 'Foo[T[0]]',
+      modes: ['typescript'],
+      expected: {
+        type: 'JsdocTypeNamePath',
+        pathType: 'property-brackets',
+        left: {
+          type: 'JsdocTypeName',
+          value: 'Foo'
+        },
+        right: {
+          type: 'JsdocTypeIndexedAccessIndex',
+          right: {
+            type: 'JsdocTypeNamePath',
+            pathType: 'property-brackets',
+            left: {
+              type: 'JsdocTypeName',
+              value: 'T'
+            },
+            right: {
+              type: 'JsdocTypeProperty',
+              value: '0',
+              meta: {
+                quote: undefined
+              }
+            }
+          }
+        }
+      }
+    })
+  })
 })


### PR DESCRIPTION
fix: parse nested indexed access in TypeScript conditional and name-path expressions