### PR TITLE
feat(typescript): parse infer in mapped conditional function types

### DIFF
--- a/src/grammars/typescriptGrammar.ts
+++ b/src/grammars/typescriptGrammar.ts
@@ -14,6 +14,7 @@ import { createTupleParslet } from '../parslets/TupleParslet.js'
 import { createVariadicParslet } from '../parslets/VariadicParslet.js'
 import { typeOfParslet } from '../parslets/TypeOfParslet.js'
 import { keyOfParslet } from '../parslets/KeyOfParslet.js'
+import { inferParslet } from '../parslets/InferParslet.js'
 import { importParslet } from '../parslets/ImportParslet.js'
 import { createSpecialNamePathParslet } from '../parslets/SpecialNamePathParslet.js'
 import { readonlyPropertyParslet } from '../parslets/ReadonlyPropertyParslet.js'
@@ -68,6 +69,7 @@ export const typescriptGrammar: Grammar = [
   readonlyArrayParslet,
   typeOfParslet,
   keyOfParslet,
+  inferParslet,
   importParslet,
   stringValueParslet,
   createFunctionParslet({

--- a/src/parslets/GenericParslet.ts
+++ b/src/parslets/GenericParslet.ts
@@ -16,7 +16,7 @@ export const genericParslet = composeParslet({
 
     do {
       if (parser.consume('infer')) {
-        const name = parser.parseIntermediateType(Precedence.SYMBOL)
+        const name = parser.parseIntermediateType(Precedence.NULLABLE)
         if (name.type !== 'JsdocTypeName') {
           throw new UnexpectedTypeError(name, 'A typescript infer always has to have a name.')
         }

--- a/src/parslets/InferParslet.ts
+++ b/src/parslets/InferParslet.ts
@@ -1,0 +1,21 @@
+import { composeParslet } from './Parslet.js'
+import { Precedence } from '../Precedence.js'
+import { UnexpectedTypeError } from '../errors.js'
+
+export const inferParslet = composeParslet({
+  name: 'inferParslet',
+  accept: type => type === 'infer',
+  parsePrefix: parser => {
+    parser.consume('infer')
+
+    const element = parser.parseIntermediateType(Precedence.NULLABLE)
+    if (element.type !== 'JsdocTypeName') {
+      throw new UnexpectedTypeError(element, 'A typescript infer always has to have a name.')
+    }
+
+    return {
+      type: 'JsdocTypeInfer',
+      element
+    }
+  }
+})

--- a/src/parslets/NullableParslets.ts
+++ b/src/parslets/NullableParslets.ts
@@ -6,9 +6,10 @@ import { assertRootResult } from '../assertTypes.js'
 export const nullableParslet: ParsletFunction = (parser, precedence, left) => {
   const type = parser.lexer.current.type
   const next = parser.lexer.next.type
+  const inferSuffix = left?.type === 'JsdocTypeInfer'
 
   const accept = ((left === null) && type === '?' && !isQuestionMarkUnknownType(next)) ||
-    ((left !== null) && type === '?' && Precedence.NULLABLE > precedence)
+    ((left !== null) && !inferSuffix && type === '?' && Precedence.NULLABLE > precedence)
 
   if (!accept) {
     return null

--- a/test/basics.spec.ts
+++ b/test/basics.spec.ts
@@ -84,4 +84,5 @@ describe('basics', () => {
     expect(() => parse('{123n: string}', 'typescript')).to.throw("Unexpected type: 'JsdocTypeBigInt'.")
     expect(() => parse('{123n}', 'typescript')).to.throw("Unexpected type: 'JsdocTypeBigInt'.")
   })
+
 })

--- a/test/fixtures/typescript/objects.spec.ts
+++ b/test/fixtures/typescript/objects.spec.ts
@@ -814,6 +814,145 @@ describe('typescript objects tests', () => {
     })
   })
 
+  describe('mapped type conditionals with infer function clauses', () => {
+    testFixture({
+      input: '{[K in keyof C]: C[K] extends (...args: infer A) => infer R ? ((this: E & C, ...args: A) => R) : C[K]}',
+      modes: ['typescript'],
+      expected: {
+        type: 'JsdocTypeObject',
+        meta: {
+          separator: 'comma'
+        },
+        elements: [
+          {
+            type: 'JsdocTypeObjectField',
+            key: {
+              type: 'JsdocTypeMappedType',
+              key: 'K',
+              right: {
+                type: 'JsdocTypeKeyof',
+                element: {
+                  type: 'JsdocTypeName',
+                  value: 'C'
+                }
+              }
+            },
+            optional: false,
+            readonly: false,
+            right: {
+              type: 'JsdocTypeConditional',
+              checksType: {
+                type: 'JsdocTypeNamePath',
+                left: {
+                  type: 'JsdocTypeName',
+                  value: 'C'
+                },
+                right: {
+                  type: 'JsdocTypeProperty',
+                  value: 'K',
+                  meta: {
+                    quote: undefined
+                  }
+                },
+                pathType: 'property-brackets'
+              },
+              extendsType: {
+                type: 'JsdocTypeFunction',
+                parameters: [
+                  {
+                    type: 'JsdocTypeKeyValue',
+                    key: 'args',
+                    optional: false,
+                    variadic: true,
+                    right: {
+                      type: 'JsdocTypeInfer',
+                      element: {
+                        type: 'JsdocTypeName',
+                        value: 'A'
+                      }
+                    }
+                  }
+                ],
+                returnType: {
+                  type: 'JsdocTypeInfer',
+                  element: {
+                    type: 'JsdocTypeName',
+                    value: 'R'
+                  }
+                },
+                arrow: true,
+                constructor: false,
+                parenthesis: true
+              },
+              trueType: {
+                type: 'JsdocTypeParenthesis',
+                element: {
+                  type: 'JsdocTypeFunction',
+                  parameters: [
+                    {
+                      type: 'JsdocTypeKeyValue',
+                      key: 'this',
+                      optional: false,
+                      variadic: false,
+                      right: {
+                        type: 'JsdocTypeIntersection',
+                        elements: [
+                          {
+                            type: 'JsdocTypeName',
+                            value: 'E'
+                          },
+                          {
+                            type: 'JsdocTypeName',
+                            value: 'C'
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      type: 'JsdocTypeKeyValue',
+                      key: 'args',
+                      optional: false,
+                      variadic: true,
+                      right: {
+                        type: 'JsdocTypeName',
+                        value: 'A'
+                      }
+                    }
+                  ],
+                  returnType: {
+                    type: 'JsdocTypeName',
+                    value: 'R'
+                  },
+                  arrow: true,
+                  constructor: false,
+                  parenthesis: true
+                }
+              },
+              falseType: {
+                type: 'JsdocTypeNamePath',
+                left: {
+                  type: 'JsdocTypeName',
+                  value: 'C'
+                },
+                right: {
+                  type: 'JsdocTypeProperty',
+                  value: 'K',
+                  meta: {
+                    quote: undefined
+                  }
+                },
+                pathType: 'property-brackets'
+              }
+            },
+            meta: {
+              quote: undefined
+            }
+          }
+        ]
+      }
+    })
+  })
+
   describe('mapped type with string literal union keys and function value', () => {
     testFixture({
       input: '{[key in "abc"|"def"]?: (node: Node, ...extraArgs: any[]) => void}',


### PR DESCRIPTION
feat(typescript): parse infer in mapped conditional function types

- add dedicated infer parslet support in TypeScript grammar
- fix nullable suffix handling so conditional question marks are not consumed after infer
- align generic infer name parsing with conditional infer parsing
- add regression coverage for mapped conditional function inference in fixture-based object tests